### PR TITLE
Enum Analyzer

### DIFF
--- a/Gu.Analyzers.Analyzers/GU0060EnumMemberValueConflictsWithAnother.cs
+++ b/Gu.Analyzers.Analyzers/GU0060EnumMemberValueConflictsWithAnother.cs
@@ -1,5 +1,3 @@
-using System.Linq.Expressions;
-
 namespace Gu.Analyzers
 {
     using System;
@@ -67,7 +65,6 @@ namespace Gu.Analyzers
                 return;
             }
 
-            var enumUnderlyingType = enumSymbol.EnumUnderlyingType;
             var hasFlagsAttribute = HasFlagsAttribute(enumSymbol);
             var enumMembers = enumDeclaration.Members;
 

--- a/Gu.Analyzers.Analyzers/GU0060EnumMemberValueConflictsWithAnother.cs
+++ b/Gu.Analyzers.Analyzers/GU0060EnumMemberValueConflictsWithAnother.cs
@@ -68,8 +68,13 @@ namespace Gu.Analyzers
             }
 
             var enumUnderlyingType = enumSymbol.EnumUnderlyingType;
-            var hasFlagAttribute = HasFlagsAttribute(enumSymbol);
+            var hasFlagsAttribute = HasFlagsAttribute(enumSymbol);
             var enumMembers = enumDeclaration.Members;
+
+            if (!hasFlagsAttribute)
+            {
+                return;
+            }
 
             ulong bitSumOfLiterals = 0;
             foreach (var enumMember in enumMembers)

--- a/Gu.Analyzers.Analyzers/GU0060EnumMemberValueConflictsWithAnother.cs
+++ b/Gu.Analyzers.Analyzers/GU0060EnumMemberValueConflictsWithAnother.cs
@@ -1,0 +1,49 @@
+namespace Gu.Analyzers
+{
+    using System.Collections.Immutable;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    internal class GU0060EnumMemberValueConflictsWithAnother : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "GU0060";
+        private const string Title = "Enum member value conflict.";
+        private const string MessageFormat = "Enum member value conflicts with another.";
+        private const string Description = "The enum member has a value shared with the other enum member, but it's not explicitly declared as its alias. To fix this, assign a enum member";
+        private static readonly string HelpLink = Analyzers.HelpLink.ForId(DiagnosticId);
+
+        private static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
+            id: DiagnosticId,
+            title: Title,
+            messageFormat: MessageFormat,
+            category: AnalyzerCategory.Correctness,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: AnalyzerConstants.EnabledByDefault,
+            description: Description,
+            helpLinkUri: HelpLink);
+
+        /// <inheritdoc/>
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+            ImmutableArray.Create(Descriptor);
+
+        /// <inheritdoc/>
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(this.HandleEnumMember, SyntaxKind.EnumMemberDeclaration);
+        }
+
+        private void HandleEnumMember(SyntaxNodeAnalysisContext context)
+        {
+            if (context.IsExcludedFromAnalysis())
+            {
+                return;
+            }
+
+            // context.ReportDiagnostic(Diagnostic.Create(Descriptor, objectCreation.GetLocation()));
+        }
+    }
+}

--- a/Gu.Analyzers.Analyzers/GU0060EnumMemberValueConflictsWithAnother.cs
+++ b/Gu.Analyzers.Analyzers/GU0060EnumMemberValueConflictsWithAnother.cs
@@ -1,10 +1,8 @@
-using System.Linq.Expressions;
-using System.Threading;
-
 namespace Gu.Analyzers
 {
     using System;
     using System.Collections.Immutable;
+    using System.Threading;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/Gu.Analyzers.Analyzers/GU0060EnumMemberValueConflictsWithAnother.cs
+++ b/Gu.Analyzers.Analyzers/GU0060EnumMemberValueConflictsWithAnother.cs
@@ -62,7 +62,10 @@ namespace Gu.Analyzers
                 {
                     bool isEnumMember = sema.GetSymbolSafe(identifier, cancellationToken)
                                             .TryGetSingleDeclaration(cancellationToken, out EnumMemberDeclarationSyntax _);
-                    return isEnumMember;
+                    if (!isEnumMember)
+                    {
+                        return false;
+                    }
                 }
             }
 

--- a/Gu.Analyzers.Analyzers/Gu.Analyzers.Analyzers.csproj
+++ b/Gu.Analyzers.Analyzers/Gu.Analyzers.Analyzers.csproj
@@ -65,6 +65,7 @@
     <Compile Include="GU0035ImplementIDisposable.cs" />
     <Compile Include="GU0037DontMixInjectedAndCreatedForMember.cs" />
     <Compile Include="GU0050IgnoreEventsWhenSerializing.cs" />
+    <Compile Include="GU0060EnumMemberValueConflictsWithAnother.cs" />
     <Compile Include="GU0051XmlSerializerNotCached.cs" />
     <Compile Include="Helpers\DebugInfo.cs" />
     <Compile Include="Helpers\AsyncAwait.cs" />

--- a/Gu.Analyzers.Analyzers/Helpers/KnownSymbols/KnownSymbol.cs
+++ b/Gu.Analyzers.Analyzers/Helpers/KnownSymbols/KnownSymbol.cs
@@ -41,6 +41,8 @@ namespace Gu.Analyzers
         internal static readonly QualifiedType ImmutableDictionaryOfTKeyTValue = Create("System.Collections.Immutable.ImmutableDictionary`2");
         internal static readonly QualifiedType ImmutableSortedDictionaryOfTKeyTValue = Create("System.Collections.Immutable.ImmutableSortedDictionary`2");
 
+        internal static readonly QualifiedType FlagsAttribute = Create("System.FlagsAttribute");
+
         internal static readonly StringBuilderType StringBuilder = new StringBuilderType();
 
         internal static readonly TextReaderType TextReader = new TextReaderType();

--- a/Gu.Analyzers.Test/GU0060EnumMemberValueConflictsWithAnother/Diagnostics.cs
+++ b/Gu.Analyzers.Test/GU0060EnumMemberValueConflictsWithAnother/Diagnostics.cs
@@ -90,5 +90,26 @@ public enum Bad
             await this.VerifyCSharpDiagnosticAsync(new[] { testCode }, expected)
                       .ConfigureAwait(false);
         }
+
+        [Test]
+        public async Task ExplicitValueSharingBitshifts()
+        {
+            var testCode = @"
+using System;
+
+[Flags]
+public enum Bad
+{
+    A = 1 << 0,
+    B = 1 << 1,
+    C = 1 << 2,
+    ↓Baaaaaaad = 1 << 2
+}";
+            var expected = this.CSharpDiagnostic()
+                               .WithLocationIndicated(ref testCode)
+                               .WithMessage("Enum member value conflicts with another.");
+            await this.VerifyCSharpDiagnosticAsync(new[] { testCode }, expected)
+                      .ConfigureAwait(false);
+        }
     }
 }

--- a/Gu.Analyzers.Test/GU0060EnumMemberValueConflictsWithAnother/Diagnostics.cs
+++ b/Gu.Analyzers.Test/GU0060EnumMemberValueConflictsWithAnother/Diagnostics.cs
@@ -1,0 +1,49 @@
+﻿namespace Gu.Analyzers.Test.GU0060EnumMemberValueConflictsWithAnother
+{
+    using System.Threading.Tasks;
+
+    using NUnit.Framework;
+
+    internal class Diagnostics : DiagnosticVerifier<Analyzers.GU0060EnumMemberValueConflictsWithAnother>
+    {
+        [Test]
+        public async Task ImplicitValueSharing()
+        {
+            var testCode = @"
+using System;
+
+[Flags]
+public enum Bad2
+{
+    A = 1,
+    B = 2,
+    Baaaaaaad = 2
+}";
+            var expected = this.CSharpDiagnostic()
+                               .WithLocationIndicated(ref testCode)
+                               .WithMessage("Enum member value conflicts with another.");
+            await this.VerifyCSharpDiagnosticAsync(new[] { testCode }, expected)
+                      .ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task ImplicitValueSharingWithBitwiseSum()
+        {
+            var testCode = @"
+using System;
+
+[Flags]
+public enum Bad
+{
+    A = 1,
+    B = 2,
+    Baaaaaaad = 3
+}";
+            var expected = this.CSharpDiagnostic()
+                               .WithLocationIndicated(ref testCode)
+                               .WithMessage("Enum member value conflicts with another.");
+            await this.VerifyCSharpDiagnosticAsync(new[] { testCode }, expected)
+                      .ConfigureAwait(false);
+        }
+    }
+}

--- a/Gu.Analyzers.Test/GU0060EnumMemberValueConflictsWithAnother/Diagnostics.cs
+++ b/Gu.Analyzers.Test/GU0060EnumMemberValueConflictsWithAnother/Diagnostics.cs
@@ -7,7 +7,7 @@
     internal class Diagnostics : DiagnosticVerifier<Analyzers.GU0060EnumMemberValueConflictsWithAnother>
     {
         [Test]
-        public async Task ImplicitValueSharing()
+        public async Task ExplicitValueSharing()
         {
             var testCode = @"
 using System;
@@ -27,7 +27,7 @@ public enum Bad2
         }
 
         [Test]
-        public async Task ImplicitValueSharingWithBitwiseSum()
+        public async Task ExplicitValueSharingWithBitwiseSum()
         {
             var testCode = @"
 using System;

--- a/Gu.Analyzers.Test/GU0060EnumMemberValueConflictsWithAnother/Diagnostics.cs
+++ b/Gu.Analyzers.Test/GU0060EnumMemberValueConflictsWithAnother/Diagnostics.cs
@@ -111,5 +111,25 @@ public enum Bad
             await this.VerifyCSharpDiagnosticAsync(new[] { testCode }, expected)
                       .ConfigureAwait(false);
         }
+
+        [Test]
+        public async Task ExplicitValueSharingNonFlag()
+        {
+            var testCode = @"
+using System;
+
+public enum Bad
+{
+    A,
+    B,
+    C,
+    ↓Baaaaaaad = 2
+}";
+            var expected = this.CSharpDiagnostic()
+                               .WithLocationIndicated(ref testCode)
+                               .WithMessage("Enum member value conflicts with another.");
+            await this.VerifyCSharpDiagnosticAsync(new[] { testCode }, expected)
+                      .ConfigureAwait(false);
+        }
     }
 }

--- a/Gu.Analyzers.Test/GU0060EnumMemberValueConflictsWithAnother/Diagnostics.cs
+++ b/Gu.Analyzers.Test/GU0060EnumMemberValueConflictsWithAnother/Diagnostics.cs
@@ -131,5 +131,25 @@ public enum Bad
             await this.VerifyCSharpDiagnosticAsync(new[] { testCode }, expected)
                       .ConfigureAwait(false);
         }
+
+        [Test]
+        public async Task ExplicitValueSharingPartial()
+        {
+            var testCode = @"
+using System;
+
+[Flags]
+public enum Bad
+{
+    A = 1,
+    B = 2,
+    ↓Baaaaaaad = A | 2
+}";
+            var expected = this.CSharpDiagnostic()
+                               .WithLocationIndicated(ref testCode)
+                               .WithMessage("Enum member value conflicts with another.");
+            await this.VerifyCSharpDiagnosticAsync(new[] { testCode }, expected)
+                      .ConfigureAwait(false);
+        }
     }
 }

--- a/Gu.Analyzers.Test/GU0060EnumMemberValueConflictsWithAnother/Diagnostics.cs
+++ b/Gu.Analyzers.Test/GU0060EnumMemberValueConflictsWithAnother/Diagnostics.cs
@@ -17,7 +17,7 @@ public enum Bad2
 {
     A = 1,
     B = 2,
-    Baaaaaaad = 2
+    ↓Baaaaaaad = 2
 }";
             var expected = this.CSharpDiagnostic()
                                .WithLocationIndicated(ref testCode)
@@ -37,7 +37,7 @@ public enum Bad
 {
     A = 1,
     B = 2,
-    Baaaaaaad = 3
+    ↓Baaaaaaad = 3
 }";
             var expected = this.CSharpDiagnostic()
                                .WithLocationIndicated(ref testCode)

--- a/Gu.Analyzers.Test/GU0060EnumMemberValueConflictsWithAnother/Diagnostics.cs
+++ b/Gu.Analyzers.Test/GU0060EnumMemberValueConflictsWithAnother/Diagnostics.cs
@@ -7,6 +7,27 @@
     internal class Diagnostics : DiagnosticVerifier<Analyzers.GU0060EnumMemberValueConflictsWithAnother>
     {
         [Test]
+        public async Task ImplicitValueSharing()
+        {
+            var testCode = @"
+using System;
+
+[Flags]
+public enum Bad
+{
+    None,
+    A,
+    B,
+    ↓Baaaaaaad
+}";
+            var expected = this.CSharpDiagnostic()
+                               .WithLocationIndicated(ref testCode)
+                               .WithMessage("Enum member value conflicts with another.");
+            await this.VerifyCSharpDiagnosticAsync(new[] { testCode }, expected)
+                      .ConfigureAwait(false);
+        }
+
+        [Test]
         public async Task ExplicitValueSharing()
         {
             var testCode = @"
@@ -38,6 +59,30 @@ public enum Bad
     A = 1,
     B = 2,
     ↓Baaaaaaad = 3
+}";
+            var expected = this.CSharpDiagnostic()
+                               .WithLocationIndicated(ref testCode)
+                               .WithMessage("Enum member value conflicts with another.");
+            await this.VerifyCSharpDiagnosticAsync(new[] { testCode }, expected)
+                      .ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task ExplicitValueSharingDifferentBases()
+        {
+            var testCode = @"
+using System;
+
+[Flags]
+public enum Bad
+{
+    A = 1,
+    B = 2,
+    C = 4,
+    D = 8,
+    E = 16,
+    F = 32,
+    ↓Baaaaaaad = 0x0F
 }";
             var expected = this.CSharpDiagnostic()
                                .WithLocationIndicated(ref testCode)

--- a/Gu.Analyzers.Test/GU0060EnumMemberValueConflictsWithAnother/HappyPath.cs
+++ b/Gu.Analyzers.Test/GU0060EnumMemberValueConflictsWithAnother/HappyPath.cs
@@ -56,5 +56,22 @@ public enum Bad
             await this.VerifyHappyPathAsync(testCode)
                       .ConfigureAwait(false);
         }
+
+        [Test]
+        public async Task AliasingEnumMembersNonFlag()
+        {
+            var testCode = @"
+using System;
+
+public enum Bad
+{
+    None,
+    A,
+    B,
+    Baaaaaaad = B
+}";
+            await this.VerifyHappyPathAsync(testCode)
+                      .ConfigureAwait(false);
+        }
     }
 }

--- a/Gu.Analyzers.Test/GU0060EnumMemberValueConflictsWithAnother/HappyPath.cs
+++ b/Gu.Analyzers.Test/GU0060EnumMemberValueConflictsWithAnother/HappyPath.cs
@@ -1,0 +1,43 @@
+namespace Gu.Analyzers.Test.GU0060EnumMemberValueConflictsWithAnother
+{
+    using System.Threading.Tasks;
+
+    using NUnit.Framework;
+
+    internal class HappyPath : HappyPathVerifier<Analyzers.GU0060EnumMemberValueConflictsWithAnother>
+    {
+        [Test]
+        public async Task ExplicitAlias()
+        {
+            var testCode = @"
+using System;
+
+[Flags]
+public enum Good
+{
+    A = 1,
+    B = 2,
+    Gooooood = B
+}";
+            await this.VerifyHappyPathAsync(testCode)
+                      .ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task ExplicitBitwiseOrSum()
+        {
+            var testCode = @"
+using System;
+
+[Flags]
+public enum Good
+{
+    A = 1,
+    B = 2,
+    Gooooood = A | B
+}";
+            await this.VerifyHappyPathAsync(testCode)
+                      .ConfigureAwait(false);
+        }
+    }
+}

--- a/Gu.Analyzers.Test/GU0060EnumMemberValueConflictsWithAnother/HappyPath.cs
+++ b/Gu.Analyzers.Test/GU0060EnumMemberValueConflictsWithAnother/HappyPath.cs
@@ -39,5 +39,22 @@ public enum Good
             await this.VerifyHappyPathAsync(testCode)
                       .ConfigureAwait(false);
         }
+
+        [Test]
+        public async Task SequentialNonFlagEnum()
+        {
+            var testCode = @"
+using System;
+
+public enum Bad
+{
+    None,
+    A,
+    B,
+    Baaaaaaad
+}";
+            await this.VerifyHappyPathAsync(testCode)
+                      .ConfigureAwait(false);
+        }
     }
 }

--- a/Gu.Analyzers.Test/Gu.Analyzers.Test.csproj
+++ b/Gu.Analyzers.Test/Gu.Analyzers.Test.csproj
@@ -99,6 +99,8 @@
     <Compile Include="GU0037DontMixInjectedAndCreatedForMemberTests\HappyPath.Rx.cs" />
     <Compile Include="GU0009UseNamedParametersForBooleansTests\Diagnostics.cs" />
     <Compile Include="GU0009UseNamedParametersForBooleansTests\HappyPath.cs" />
+    <Compile Include="GU0060EnumMemberValueConflictsWithAnother\Diagnostics.cs" />
+    <Compile Include="GU0060EnumMemberValueConflictsWithAnother\HappyPath.cs" />
     <Compile Include="GU0051XmlSerializerNotCached\Diagnostics.cs" />
     <Compile Include="GU0051XmlSerializerNotCached\HappyPath.cs" />
     <Compile Include="HappyPathWithAll.cs" />

--- a/documentation/GU0060.md
+++ b/documentation/GU0060.md
@@ -1,0 +1,63 @@
+# GU0060
+## Enum member value conflict.
+
+<!-- start generated table -->
+<table>
+<tr>
+  <td>CheckId</td>
+  <td>GU0060</td>
+</tr>
+<tr>
+  <td>Severity</td>
+  <td>Warning</td>
+</tr>
+<tr>
+  <td>Category</td>
+  <td>Gu.Analyzers.Correctness</td>
+</tr>
+<tr>
+  <td>TypeName</td>
+  <td><a href="https://github.com/JohanLarsson/Gu.Analyzers/blob/master/Gu.Analyzers.Analyzers/GU0060EnumMemberValueConflictsWithAnother.cs">GU0060EnumMemberValueConflictsWithAnother</a></td>
+</tr>
+</table>
+<!-- end generated table -->
+
+## Description
+
+The enum member has a value shared with the other enum member, but it's not explicitly declared as its alias. To fix this, assign a enum member
+
+## Motivation
+
+ADD MOTIVATION HERE
+
+## How to fix violations
+
+ADD HOW TO FIX VIOLATIONS HERE
+
+<!-- start generated config severity -->
+## Configure severity
+
+### Via ruleset file.
+
+Configure the severity per project, for more info see [MSDN](https://msdn.microsoft.com/en-us/library/dd264949.aspx).
+
+### Via #pragma directive.
+```C#
+#pragma warning disable GU0060 // Enum member value conflict.
+Code violating the rule here
+#pragma warning restore GU0060 // Enum member value conflict.
+```
+
+Or put this at the top of the file to disable all instances.
+```C#
+#pragma warning disable GU0060 // Enum member value conflict.
+```
+
+### Via attribute `[SuppressMessage]`.
+
+```C#
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Gu.Analyzers.Correctness", 
+    "GU0060:Enum member value conflict.", 
+    Justification = "Reason...")]
+```
+<!-- end generated config severity -->


### PR DESCRIPTION
Warns on enum members with the same values which aren't aliased to another. Handles flags and non-flag enums. 